### PR TITLE
RMET-2916 ::: Add ScanBarcode Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
-## 1.0.0
+## [Unreleased]
+
+### Cordova Wrapper
+
+- Add `scanBarcode` method (https://outsystemsrd.atlassian.net/browse/RMET-2916).

--- a/www/OSBarcode.js
+++ b/www/OSBarcode.js
@@ -1,5 +1,18 @@
 var exec = require('cordova/exec');
 
-exports.coolMethod = function (arg0, success, error) {
-    exec(success, error, 'OSBarcode', 'coolMethod', [arg0]);
-};
+exports.scanBarcode = function (options, successCallback, errorCallback) {
+    options = options || {};
+
+    let scanInstructions = options.scanInstructions;
+    let cameraDirection = options.cameraDirection;
+    let scanOrientation = options.scanOrientation;
+    let scanButton = !!options.scanButton;
+    let scanText = options.scanText;
+    let hint = options.hint;
+    let androidScanningLibrary = options.androidScanningLibrary;
+
+    let args = [{scanInstructions, cameraDirection, scanOrientation, scanButton, scanText, hint, androidScanningLibrary}];
+
+    // temporary, while the bridge doesn't implement the native library connection.
+    console.log(args);
+}


### PR DESCRIPTION
## Description
Add `ScanBarcode` method to `OSBarcode.js`, allowing the interaction between the OutSystems and the (to be implemented) native layers.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2916

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [x] JavaScript

## Tests
The feature was manually tested and with success. The following is what is printed as a result of calling the method from the OutSystems plugin.

`[{"scanInstructions":"Center the code on the frame to scan it.","cameraDirection":"1","scanOrientation":"3","scanButton":false,"scanText":"Scan","hint":17,"androidScanningLibrary":""}]`

## Checklist
- [x] Pull request title follows the format `RMET-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
