### PR TITLE
RMET-2916 ::: Add Support for Old ScanBarcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,5 @@ The changes documented here do not include those from the original repository.
 
 ### Cordova Wrapper
 
+- Add support for plugin's old version of the `scanBarcode` method (https://outsystemsrd.atlassian.net/browse/RMET-2916).
 - Add `scanBarcode` method (https://outsystemsrd.atlassian.net/browse/RMET-2916).

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,6 +6,15 @@
   <js-module name="OSBarcode" src="www/OSBarcode.js">
     <clobbers target="cordova.plugins.OSBarcode"/>
   </js-module>
+
+  <js-module name="OSBarcodeScanner" src="www/OSBarcodeScanner.js">
+    <clobbers target="cordova.plugins.OSBarcodeScanner"/>
+  </js-module>
+
+  <js-module name="OSBarcodeConstants" src="www/OSBarcodeConstants.js">
+    <clobbers target="OSBarcodeConstants"/>
+  </js-module>
+
   <platform name="android">
     <config-file parent="/*" target="res/xml/config.xml">
       <feature name="OSBarcode">

--- a/www/OSBarcodeConstants.js
+++ b/www/OSBarcodeConstants.js
@@ -1,0 +1,26 @@
+module.exports = {
+	Hint: {
+		QR_CODE: 0,
+		AZTEC: 1,
+		CODABAR: 2,
+		CODE_39: 3,
+		CODE_93: 4,
+		CODE_128: 5,
+		DATA_MATRIX: 6,
+		MAXICODE: 7,
+		ITF: 8,
+		EAN_13: 9,
+		EAN_8: 10,
+		PDF_417: 11,
+		RSS_14: 12,
+		RSS_EXPANDED: 13,
+		UPC_A: 14,
+		UPC_E: 15,
+		UPC_EAN_EXTENSION: 16,
+		ALL: 17
+	},
+	AndroidScanningLibrary: {
+		ZXING: 'zxing',
+		MLKIT: 'mlkit'
+	}
+}

--- a/www/OSBarcodeScanner.js
+++ b/www/OSBarcodeScanner.js
@@ -1,0 +1,19 @@
+var exec = require('cordova/exec');
+var Barcode = require('./OSBarcode');
+var BarcodeConstants = require('./OSBarcodeConstants');
+
+exports.scan = function (options, successCallback, errorCallback) {
+    options = options || {};
+
+    let args = {
+        scanInstructions: options.scan_instructions,
+        cameraDirection: options.camera_direction,
+        scanOrientation: options.scan_orientation,
+        scanButton: options.scan_button,
+        scanText: options.scan_button_text,
+        hint: BarcodeConstants.Hint.ALL,
+        androidScanningLibrary: null
+    };
+
+    Barcode.scanBarcode(args, successCallback, errorCallback);
+}


### PR DESCRIPTION
## Description
- Add the previous version of the plugin's `scanBarcode` in order to achieve retro compatibility. In the background, this method calls the new version's, mapping its parameters accordingly. 
- Add the OutSystems plugin's Static Entities to the `OSBarcodeConstants.js` file.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2916

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [x] JavaScript

## Tests
The feature was manually tested and with success. The following is what is printed as a result of calling the method from the OutSystems plugin.

`[{"scanInstructions":"Center the code on the frame to scan it.","cameraDirection":"1","scanOrientation":"3","scanButton":false,"scanText":"Scan","hint":17,"androidScanningLibrary":null}]`

## Checklist
- [x] Pull request title follows the format `RMET-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
