### PR TITLE
RMET-3263 create CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# O11/ODC
+* @OutSystems/rd-mobile-ecosystem


### PR DESCRIPTION
## Description
This PR adds the required CODEOWNERS file to the repo with a comment designating if the plugin relates to ODC or O11 or both.

## Context
New requirements before March 15th 2024, all repos must have a CODEOWNERS file.
[Issue Link](https://outsystemsrd.atlassian.net/browse/RMET-3263)

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [ ] JavaScript
