### PR TITLE
RMET-3394 Barcode Plugin - Add serializable annotation to avoid problems with code obfuscation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [1.1.2]
+
+### 21-05-2024
+- Fix: Updates dependency to `OSBarcodeLib-Android`, adding serializable annotation to avoid problems with code obfuscation (https://outsystemsrd.atlassian.net/browse/RMET-3394).
+
 ## [1.1.1]
 
 ### 30-04-2024

--- a/src/android/com/outsystems/plugins/barcode/build.gradle
+++ b/src/android/com/outsystems/plugins/barcode/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.0@aar")
-    implementation("com.github.outsystems:osbarcode-android:1.1.1.1@aar")
+    implementation("com.github.outsystems:osbarcode-android:1.1.2@aar")
 
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation "androidx.activity:activity-ktx:1.4.0"

--- a/src/android/com/outsystems/plugins/barcode/build.gradle
+++ b/src/android/com/outsystems/plugins/barcode/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.0@aar")
-    implementation("com.github.outsystems:osbarcode-android:1.1.1@aar")
+    implementation("com.github.outsystems:osbarcode-android:1.1.1.1@aar")
 
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation "androidx.activity:activity-ktx:1.4.0"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Updates dependency to `OSBarcodeLib-Android` , adding `@SerializedName` annotation to the `OSBARCScanParameters` fields to avoid problems with code obfuscation (AppShield).

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3394

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested with Android 14 (Pixel 7), using a MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=ef2a0b6346fd7566d4d4f6f4c395dc16b57edaf9

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
