### PR TITLE
Prepare v`1.1.4` Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
-## [Unreleased]
+## [1.1.4]
 
 ### iOS
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.barcode",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Cordova Bridge for the OutSystems Officially Supported Barcode Plugin.",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -51,7 +51,7 @@
         <source url="https://cdn.cocoapods.org/"/>
       </config>
       <pods use-frameworks="true">
-        <pod name="OSBarcodeLib" spec="1.1.0" />
+        <pod name="OSBarcodeLib" spec="1.1.1" />
       </pods>
     </podspec>
   </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.plugins.barcode" version="1.1.3" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.barcode" version="1.1.4" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>OSBarcode</name>
   <description>Cordova Bridge for the OutSystems Officially Supported Barcode Plugin.</description>
   <author>OutSystems Inc</author>


### PR DESCRIPTION
Includes updating the iOS library to the latest `1.1.1` version.