### PR TITLE
RMET-3379 - Barcode Plugin - Remove usage of `runBlocking`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [1.1.5]
 
+### 23-08-2024
+- Fix: Stop using runBlocking when scanning a code (https://outsystemsrd.atlassian.net/browse/RMET-3379).
+
 ### 22-08-2024
 - Fix: Avoid UI bug on background when layout is portrait (https://outsystemsrd.atlassian.net/browse/RMET-3379).
 

--- a/src/android/com/outsystems/plugins/barcode/OSBarcode.kt
+++ b/src/android/com/outsystems/plugins/barcode/OSBarcode.kt
@@ -28,17 +28,13 @@ class OSBarcode : CordovaImplementation() {
         callbackContext: CallbackContext
     ): Boolean {
         this.callbackContext = callbackContext
-        val result = runBlocking {
-            when (action) {
-                "scanBarcode" -> {
-                    scan(args)
-                }
-
-                else -> false
+        when (action) {
+            "scanBarcode" -> {
+                scan(args)
+                return true
             }
-            true
+            else -> return false
         }
-        return result
     }
 
     override fun initialize(cordova: CordovaInterface, webView: CordovaWebView) {

--- a/src/android/com/outsystems/plugins/barcode/build.gradle
+++ b/src/android/com/outsystems/plugins/barcode/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("com.github.outsystems:osbarcode-android:1.1.3-dev2@aar")
+    implementation("com.github.outsystems:osbarcode-android:1.1.3@aar")
 
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation "androidx.activity:activity-ktx:1.4.0"

--- a/src/android/com/outsystems/plugins/barcode/build.gradle
+++ b/src/android/com/outsystems/plugins/barcode/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("com.github.outsystems:osbarcode-android:1.1.3@aar")
+    implementation("com.github.outsystems:osbarcode-android:1.1.3-dev2@aar")
 
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation "androidx.activity:activity-ktx:1.4.0"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Removes the usage of `runBlocking` when calling the code to open the scanner, it is unnecessary and we shouldn't be blocking the main thread.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3379

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested on Android 15 (Pixel 7), Android 13 (Samsung A51), and Android 12 (Pixel 3 XL)

MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=626b0f78bb4b478d3245dce3cea4defd254268d3

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RMET-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
