### PR TITLE
RMET-3374 - Barcode Plugin - Use confidence level for readings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ The changes documented here do not include those from the original repository.
 
 ## [1.1.5]
 
+### 27-08-2024
+- Fix: iOS - Use confidence level for code readings (https://outsystemsrd.atlassian.net/browse/RMET-3374).
+
 ### 23-08-2024
-- Fix: Stop using runBlocking when scanning a code (https://outsystemsrd.atlassian.net/browse/RMET-3379).
+- Fix: Android - Stop using runBlocking when scanning a code (https://outsystemsrd.atlassian.net/browse/RMET-3379).
 
 ### 22-08-2024
-- Fix: Avoid UI bug on background when layout is portrait (https://outsystemsrd.atlassian.net/browse/RMET-3379).
+- Fix: Android - Avoid UI bug on background when layout is portrait (https://outsystemsrd.atlassian.net/browse/RMET-3379).
 
 ## [1.1.4]
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -51,7 +51,7 @@
         <source url="https://cdn.cocoapods.org/"/>
       </config>
       <pods use-frameworks="true">
-        <pod name="OSBarcodeLib" spec="1.1.1" />
+        <pod name="OSBarcodeLib" spec="1.1.2" />
       </pods>
     </podspec>
   </platform>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Updates dependency to `OSBarcodeLib-iOS` to version `1.1.2`, to use confidence level in code readings.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RMET-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
