### PR TITLE
RMET-3602 ::: Updated libs for 16KB page alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+### 08-11-2024
+- Fix: Android - Update libraries for supporting 16KB page size (https://outsystemsrd.atlassian.net/browse/RMET-3602)
+
+### 05-11-2024
+- Fix: Android - Edge-to-edge support on Android 15 (https://outsystemsrd.atlassian.net/browse/RMET-3597)
+
 ## [1.1.6]
 
 ### 22-10-2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The changes documented here do not include those from the original repository.
 ## [Unreleased]
 
 ### 11-11-2024
-- Chore: Remove unneeded `kotlin-kapt` plugin (https://outsystemsrd.atlassian.net/browse/RMET-3803).
+- Chore: Android - Remove unneeded `kotlin-kapt` plugin (https://outsystemsrd.atlassian.net/browse/RMET-3803).
 
 ### 08-11-2024
 - Fix: Android - Update libraries for supporting 16KB page size (https://outsystemsrd.atlassian.net/browse/RMET-3602)

--- a/src/android/com/outsystems/plugins/barcode/build.gradle
+++ b/src/android/com/outsystems/plugins/barcode/build.gradle
@@ -38,10 +38,10 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3'
 
     implementation 'com.google.zxing:core:3.4.1'
-    implementation 'com.google.mlkit:barcode-scanning:17.2.0'
-    implementation "androidx.camera:camera-camera2:1.3.0"
-    implementation "androidx.camera:camera-lifecycle:1.0.2"
-    implementation "androidx.camera:camera-view:1.0.0-alpha31"
+    implementation 'com.google.mlkit:barcode-scanning:17.3.0'
+    implementation "androidx.camera:camera-camera2:1.4.0"
+    implementation "androidx.camera:camera-lifecycle:1.4.0"
+    implementation "androidx.camera:camera-view:1.4.0"
     implementation "androidx.activity:activity-compose:1.4.0"
     implementation 'androidx.compose.material3:material3:1.0.0'
     implementation 'androidx.compose.material3:material3-window-size-class:1.0.0'

--- a/src/android/com/outsystems/plugins/barcode/build.gradle
+++ b/src/android/com/outsystems/plugins/barcode/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("com.github.outsystems:osbarcode-android:1.1.4@aar")
+    implementation("com.github.outsystems:osbarcode-android:1.1.5-dev2@aar")
 
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation "androidx.activity:activity-ktx:1.4.0"


### PR DESCRIPTION
## Description

Update mlkit and camera libraries to latest version, that have their shared libraries (.so files) 16KB-aligned.

Note that `libsqlc-ndk-native-driver.so` is not 16KB-aligned, and any app that uses it crashes, that is because the [SQL Cypher library needs to be updated](https://discuss.zetetic.net/t/android-sqlcipher-support-for-android-sdk-35-16k-page-sizes/6460/10) - out of scope of this repo.

## Context

- https://outsystemsrd.atlassian.net/browse/RMET-3602
- https://outsystemsrd.atlassian.net/wiki/spaces/RDME/pages/4426137659/iOS+18+Android+15+Assessment
- https://developer.android.com/guide/practices/page-sizes

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Steps:

1. Generate a MABS11 build with barcode plugin pointing to the latest released version
2. Run [check_elf_alignment.sh](https://cs.android.com/android/platform/superproject/main/+/main:system/extras/tools/check_elf_alignment.sh) script: `./check_elf_alignment.sh <apk_file> | grep arm64-v8a`
```
/var/folders/ln/4t6dd54d3c1b3wm92vv9pggc0000gn/T/barcode-MABS11-no16kb_out_XXXXX.23adACzP6z/lib/arm64-v8a/libsqlc-ndk-native-driver.so: \e[31mUNALIGNED\e[0m (2**12)
/var/folders/ln/4t6dd54d3c1b3wm92vv9pggc0000gn/T/barcode-MABS11-no16kb_out_XXXXX.23adACzP6z/lib/arm64-v8a/libbarhopper_v3.so: \e[31mUNALIGNED\e[0m (2**12)
/var/folders/ln/4t6dd54d3c1b3wm92vv9pggc0000gn/T/barcode-MABS11-no16kb_out_XXXXX.23adACzP6z/lib/arm64-v8a/libimage_processing_util_jni.so: \e[31mUNALIGNED\e[0m (2**12
```
3. Point the plugin version (in Extensibility Configuration) to this branch.
4. Run again `./check_elf_alignment.sh <apk_file> | grep arm64-v8a` - ".so" files associated with mlkit and camera should be aligned
```
/var/folders/ln/4t6dd54d3c1b3wm92vv9pggc0000gn/T/barcode-MABS11-RMET-3602_out_XXXXX.rNDCwvBYgp/lib/arm64-v8a/libsqlc-ndk-native-driver.so: \e[31mUNALIGNED\e[0m (2**12)
/var/folders/ln/4t6dd54d3c1b3wm92vv9pggc0000gn/T/barcode-MABS11-RMET-3602_out_XXXXX.rNDCwvBYgp/lib/arm64-v8a/libbarhopper_v3.so: \e[32mALIGNED\e[0m (2**14)
/var/folders/ln/4t6dd54d3c1b3wm92vv9pggc0000gn/T/barcode-MABS11-RMET-3602_out_XXXXX.rNDCwvBYgp/lib/arm64-v8a/libimage_processing_util_jni.so: \e[32mALIGNED\e[0m (2**14)
```

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RMET-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
