### PR TITLE
RMET-3803 ::: Android ::: Remove Unneeded Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+### Android
+
+#### Chores
+- Remove unneeded `kotlin-kapt` plugin (https://outsystemsrd.atlassian.net/browse/RMET-3803).
+
 ## [1.1.6]
 
 ### 22-10-2024

--- a/src/android/com/outsystems/plugins/barcode/build.gradle
+++ b/src/android/com/outsystems/plugins/barcode/build.gradle
@@ -23,9 +23,6 @@ repositories{
     }
 }
 
-
-apply plugin: 'kotlin-kapt'
-
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")


### PR DESCRIPTION
## Description
Remove the `kotlin-kapt` plugin. This is causing a build issue with the Capacitor Shell and is not even required for the Cordova equivalent.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3803

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Manual testing was performed to confirm that the plugin is indeed unnecessary.

## Checklist
- [x] Pull request title follows the format `RMET-XXXX <title>`
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
