### PR TITLE
Feature ::: Android ::: Edge-to-edge in all Android versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+### 26-11-2024
+- Feature: Android - Support Edge-to-Edge on all Android versions.
+
 ## [1.1.7]
 
 ### 11-11-2024

--- a/src/android/com/outsystems/plugins/barcode/build.gradle
+++ b/src/android/com/outsystems/plugins/barcode/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation("com.github.outsystems:osbarcode-android:1.2.0-dev1@aar")
 
     implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation "androidx.activity:activity-ktx:1.4.0"
+    implementation "androidx.activity:activity-ktx:1.9.3"
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3'

--- a/src/android/com/outsystems/plugins/barcode/build.gradle
+++ b/src/android/com/outsystems/plugins/barcode/build.gradle
@@ -26,7 +26,7 @@ repositories{
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("com.github.outsystems:osbarcode-android:1.1.5@aar")
+    implementation("com.github.outsystems:osbarcode-android:1.2.0-dev1@aar")
 
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation "androidx.activity:activity-ktx:1.4.0"


### PR DESCRIPTION
## Description

The actual changes for adding support for Edge-to-Edge in all Android versions (instead of just Android 15 or higher), are in https://github.com/OutSystems/OSBarcodeLib-Android/pull/40

## Context

Reference: https://outsystemsrd.atlassian.net/wiki/spaces/RDME/pages/4426137659/iOS+18+Android+15+Assessment


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RMET-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
