### PR TITLE
fix(android): crash on lateinit var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [2.0.1]
+
+### 02-10-2025
+
+- Fix: Android - Crash due to `kotlin.UninitializedPropertyAccessException`.
+
 ## [2.0.0]
 
 ### 01-09-2025

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.barcode",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Cordova Bridge for the OutSystems Officially Supported Barcode Plugin.",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.plugins.barcode" version="2.0.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.barcode" version="2.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>OSBarcode</name>
   <description>Cordova Bridge for the OutSystems Officially Supported Barcode Plugin.</description>
   <author>OutSystems Inc</author>

--- a/src/android/com/outsystems/plugins/barcode/build.gradle
+++ b/src/android/com/outsystems/plugins/barcode/build.gradle
@@ -26,7 +26,7 @@ repositories{
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("io.ionic.libs:ionbarcode-android:2.0.0@aar")
+    implementation("io.ionic.libs:ionbarcode-android:2.0.1@aar")
 
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation "androidx.activity:activity-ktx:1.9.3"


### PR DESCRIPTION
## Description

Crash `kotlin.UninitializedPropertyAccessException: lateinit property camera has not been initialized` - Fix via native Android library.

## Context

- https://outsystemsrd.atlassian.net/browse/RMET-4530
- https://github.com/OutSystems/OSBarcodeLib-Android/pull/52

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests

Please use either "Barcode Demo App" or "RMET-4527 Barcode App" to confirm that there is no crash.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RMET-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
